### PR TITLE
Fix path to crushftp_init.sh file.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,6 @@ echo "# User:		${CRUSH_ADMIN_USER}"
 echo "# Password:	${CRUSH_ADMIN_PASSWORD}"
 echo "########################################"
 
-chmod +x crushftp_init.sh
+chmod +x ${CRUSH_FTP_BASE_DIR}/crushftp_init.sh
 ${CRUSH_FTP_BASE_DIR}/crushftp_init.sh start
 while true; do sleep 86400; done


### PR DESCRIPTION
The current implementation of the script in `setup.sh` fails.

Logs from the container look like:
```
Unzipping CrushFTP...
########################################
# User:         admin
# Password:     admin
########################################
chmod: crushftp_init.sh: No such file or directory
/var/opt/setup.sh: line 32: /var/opt/CrushFTP9/crushftp_init.sh: Permission denied
```

I suggest fixing the path to the `crushftp_init.sh` file.
